### PR TITLE
Keep footer fixed and align AI panel with FAB

### DIFF
--- a/script.js
+++ b/script.js
@@ -144,6 +144,7 @@ function injectAIFabAndPanel(){
       if(open){
         aiqynClearNotif();          // remove ping on open
         ensureAIPanel();            // lazy-create panel
+        positionAIPanel(fab);       // place panel near button
         setTimeout(()=>{
           const input = document.getElementById("aiqyn-fab-input");
           if(input) input.focus();
@@ -245,6 +246,36 @@ function aiPanelAddMsg(text, who="bot"){
   box.scrollTop = box.scrollHeight;
 }
 
+// Position panel near FAB
+function positionAIPanel(fab){
+  const panel = document.querySelector(".ai-panel");
+  if(!panel || !fab) return;
+  const rect = fab.getBoundingClientRect();
+  const pw = panel.offsetWidth;
+  const ph = panel.offsetHeight;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  let left = rect.left + rect.width/2 - pw/2;
+  left = Math.max(6, Math.min(vw - pw - 6, left));
+  let top = rect.top - ph - 10; // try above button
+  if(top < 6){
+    top = rect.bottom + 10; // place below
+    if(top + ph > vh - 6){
+      // place to side if no vertical space
+      if(rect.left + rect.width/2 < vw/2){
+        left = rect.right + 10;
+      }else{
+        left = rect.left - pw - 10;
+      }
+      left = Math.max(6, Math.min(vw - pw - 6, left));
+      top = rect.top + rect.height/2 - ph/2;
+      top = Math.max(6, Math.min(vh - ph - 6, top));
+    }
+  }
+  panel.style.left = left + "px";
+  panel.style.top  = top + "px";
+}
+
 // Draggable FAB
 function makeDraggableFab(el){
   let dragging = false, startX=0, startY=0, startLeft=0, startTop=0;
@@ -276,11 +307,13 @@ function makeDraggableFab(el){
     const ct = Math.max(6, Math.min(vh - sz.height - 6, nt));
     el.style.left = cl + "px";
     el.style.top  = ct + "px";
+    if(document.body.classList.contains("ai-open")) positionAIPanel(el);
   };
 
   const onPointerUp = (e)=>{
     dragging = false;
     try{ el.releasePointerCapture(e.pointerId); }catch(_){}
+    if(document.body.classList.contains("ai-open")) positionAIPanel(el);
   };
 
   el.style.position = "fixed";
@@ -290,6 +323,12 @@ function makeDraggableFab(el){
   window.addEventListener("pointermove", onPointerMove);
   window.addEventListener("pointerup", onPointerUp);
 }
+
+// Reposition panel on viewport changes
+window.addEventListener("resize", () => {
+  const fab = document.querySelector(".ai-fab");
+  if(fab && document.body.classList.contains("ai-open")) positionAIPanel(fab);
+});
 
 // FAB notification ping helpers
 function aiqynSetNotif(on=true){

--- a/style.css
+++ b/style.css
@@ -85,6 +85,8 @@ body{
     radial-gradient(1200px 600px at 90% 110%, rgba(18,196,179,.10), transparent 60%),
     var(--bg);
   line-height:1.65; -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  /* reserve space for fixed footer */
+  padding-bottom:120px;
 }
 
 /* --------- TYPOGRAPHY --------- */
@@ -99,9 +101,11 @@ code,kbd{background:rgba(148,163,184,.15);padding:.1em .35em;border-radius:8px}
 /* --------- LAYOUT --------- */
 .container{max-width:1140px;margin:28px auto;padding:0 18px}
 .site-footer{
-  position:relative;text-align:center;color:var(--muted);font-size:14px;
+  position:fixed; left:0; bottom:0; width:100%;
+  text-align:center; color:var(--muted); font-size:14px;
   padding:36px 18px; overflow:hidden;
   backdrop-filter: blur(var(--glass-blur));
+  z-index:40;
 }
 .site-footer a{font-weight:700}
 
@@ -332,7 +336,7 @@ body.ai-ready .ai-fab{ display:grid; }
 
 /* Мини-панель AI (mini chat) */
 .ai-panel{
-  position:fixed; right:20px; bottom:90px; z-index:60;
+  position:fixed; z-index:60;
   width:380px; max-width:calc(100vw - 32px); height:480px;
   border-radius:18px; overflow:hidden;
   display:block; opacity:0; transform: translateY(8px) scale(.985);


### PR DESCRIPTION
## Summary
- Keep site footer fixed to the bottom of the viewport and reserve space so content isn't obscured.
- Let the AI assistant panel open near the movable FAB, re-positioning as the button moves or the viewport resizes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4117639908324bba208db69aad14a