### PR TITLE
Refine header navigation and reward display

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/ai.html
+++ b/ai.html
@@ -13,19 +13,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link active">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/assistant.html
+++ b/assistant.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html" class="active">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/blog.html
+++ b/blog.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html" class="active">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/contacts.html
+++ b/contacts.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html" class="active">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/faq.html
+++ b/faq.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html" class="active">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/index.html
+++ b/index.html
@@ -13,19 +13,16 @@
     <a href="index.html" class="active">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 

--- a/letters.html
+++ b/letters.html
@@ -10,17 +10,14 @@
   <div class="brand"><span class="logo">✨</span><span class="title">AiqynAI</span></div>
   <nav class="nav">
     <a href="index.html">Главная</a><a href="tests.html">Тесты</a><a href="universities.html">Университеты</a>
-    <a href="letters.html" class="active">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a><a href="contacts.html">Контакты</a><a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/pricing.html
+++ b/pricing.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html" class="active">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/profile.html
+++ b/profile.html
@@ -10,17 +10,14 @@
   <div class="brand"><span class="logo">✨</span><span class="title">AiqynAI</span></div>
   <nav class="nav">
     <a href="index.html">Главная</a><a href="tests.html">Тесты</a><a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a><a href="contacts.html">Контакты</a><a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
-    <a href="profile.html" class="profile-icon active" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
+    <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
   </div>
 </header>
 <main class="container">

--- a/rewards.html
+++ b/rewards.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html" class="active">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/script.js
+++ b/script.js
@@ -371,12 +371,14 @@ function injectThemeSwitch(){
   sw.append(sun, moon, thumb);
 
   // place near points if exists
-  const points = document.getElementById("pointsDisplay");
-  const profile = header.querySelector(".user-menu");
-  if(profile){
-    header.insertBefore(sw, profile.nextSibling);
-  }else if(points && points.parentElement === header){
-    header.insertBefore(sw, points.nextSibling);
+  const actions = header.querySelector(".actions");
+  if(actions){
+    const points = actions.querySelector("#pointsDisplay");
+    if(points){
+      actions.insertBefore(sw, points.nextSibling);
+    }else{
+      actions.appendChild(sw);
+    }
   }else{
     header.appendChild(sw);
   }

--- a/style.css
+++ b/style.css
@@ -160,7 +160,9 @@ code,kbd{background:rgba(148,163,184,.15);padding:.1em .35em;border-radius:8px}
 .title{font-size:18px;letter-spacing:.2px}
 
 .nav{
-  display:flex; align-items:center; gap:6px; overflow-x:auto; padding:4px 0; position:relative; z-index:1;
+  flex:1;
+  display:flex; align-items:center; justify-content:center;
+  gap:6px; overflow-x:auto; padding:4px 0; position:relative; z-index:1;
 }
 .nav::-webkit-scrollbar{height:6px}
 .nav::-webkit-scrollbar-thumb{background:rgba(148,163,184,.35);border-radius:8px}
@@ -194,37 +196,29 @@ code,kbd{background:rgba(148,163,184,.15);padding:.1em .35em;border-radius:8px}
   font-weight:700;
 }
 
-/* Profile icon + dropdown */
-.user-menu{ position:relative; display:inline-block; }
+/* Right-side actions */
+.actions{ display:flex; align-items:center; gap:6px; }
 .profile-icon{
-  display:inline-block; padding:8px; border-radius:50%;
-  text-decoration:none; color:var(--ink); border:1px solid transparent;
-  transition: background .15s ease, border-color .15s ease;
-}
-.profile-icon.active{
-  color:#0b1726;
+  display:inline-flex; align-items:center; justify-content:center;
+  width:34px; height:34px;
+  border-radius:50%; text-decoration:none;
+  border:1px solid rgba(255,255,255,.35);
   background:
-    linear-gradient(180deg, rgba(255,255,255,.65), rgba(255,255,255,.35)),
+    linear-gradient(180deg, rgba(255,255,255,.75), rgba(255,255,255,.35)),
     linear-gradient(135deg, var(--brand), var(--brand-2));
-  border-color: rgba(255,255,255,.45);
-  box-shadow: 0 6px 18px rgba(26,169,230,.25);
+  box-shadow:0 8px 22px rgba(26,169,230,.25);
+  color:#0b1726; font-size:18px;
+  transition:filter .15s ease, box-shadow .12s ease;
 }
-.profile-icon:hover{ background: linear-gradient(0deg, rgba(26,169,230,.08), rgba(26,169,230,0)); border-color: rgba(26,169,230,.20); }
-.profile-menu{
-  display:none; position:absolute; right:0; top:calc(100% + 6px);
-  background: linear-gradient(180deg, rgba(255,255,255,.95), rgba(255,255,255,.70));
-  border:1px solid var(--border); border-radius:var(--radius-sm);
-  box-shadow: var(--shadow-2);
-  backdrop-filter: blur(var(--glass-blur));
-  z-index:20; min-width:120px;
+.profile-icon:hover{
+  filter:brightness(1.03);
+  box-shadow:0 10px 28px rgba(26,169,230,.32);
 }
-.profile-menu a{ display:block; padding:8px 12px; white-space:nowrap; color:var(--ink); text-decoration:none; }
-.profile-menu a:hover{ background:rgba(26,169,230,.08); }
-.profile-menu a.active{ font-weight:700; }
-.user-menu:hover .profile-menu{ display:block; }
 
 /* Очки */
 .points{
+  display:inline-block;
+  text-decoration:none;
   font-weight:800; color:#0b1726;
   background:
     linear-gradient(180deg, rgba(255,255,255,.75), rgba(255,255,255,.35)),

--- a/tests.html
+++ b/tests.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html" class="active">Тесты</a>
     <a href="universities.html">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">

--- a/universities.html
+++ b/universities.html
@@ -9,19 +9,16 @@
     <a href="index.html">Главная</a>
     <a href="tests.html">Тесты</a>
     <a href="universities.html" class="active">Университеты</a>
-    <a href="letters.html">Мотивационное письмо</a>
+    <a href="blog.html">Блог</a>
     <a href="assistant.html">Ассистент</a>
     <a href="pricing.html">Цены</a>
     <a href="contacts.html">Контакты</a>
     <a href="faq.html">FAQ</a>
     <a href="ai.html" class="ai-link">AI</a>
   </nav>
-  <div id="pointsDisplay" class="points">⭐ 0</div>
-  <div class="user-menu">
+  <div class="actions">
+    <a id="pointsDisplay" class="points" href="rewards.html" title="Награды">⭐ 0</a>
     <a href="profile.html" class="profile-icon" title="Профиль">👤</a>
-    <div class="profile-menu">
-      <a href="rewards.html">Награды</a>
-    </div>
   </div>
 </header>
 <main class="container">


### PR DESCRIPTION
## Summary
- Replace "Мотивационное письмо" menu item with "Блог" and group reward, theme switch, and profile icons.
- Center navigation links and style right-side icons with a compact layout.
- Make reward count clickable and enlarge profile icon to match theme switch aesthetics.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a41e85ec808324ba521fda3baa63bb